### PR TITLE
Refactor elapsed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
-## 1.3.1-1 - 2025-02-05 (beta)
+## 1.3.1-1 - 2025-02-16 (beta)
+
+### Changed
+
+- Refactor the `with-elapsed-time` macro to be `report-elapsed-time!` use the proper `System/nanoTime`.
 
 ## 0.3.1-1 - 2025-02-05 (beta)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+## 1.3.1-1 - 2025-02-05 (beta)
+
 ## 0.3.1-1 - 2025-02-05 (beta)
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/prometheus-component "0.3.1-1"
+(defproject net.clojars.macielti/prometheus-component "1.3.1-1"
 
   :description "Prometheus component for integrant"
 

--- a/src/prometheus_component/core.clj
+++ b/src/prometheus_component/core.clj
@@ -5,13 +5,13 @@
             [integrant.core :as ig]
             [schema.core :as s]))
 
-(defmacro with-elapsed-time
-  "Measures the elapsed time to run the given body of code."
+(defmacro report-elapsed-time!
+  "Measures the elapsed time (msecs) to run the given body of code, reports it as a prometheus metric, and returns the result of the body."
   [registry id & body]
-  `(let [start# (System/currentTimeMillis)
+  `(let [start# (. System (nanoTime))
          result# (do ~@body)
-         end# (System/currentTimeMillis)]
-     (prometheus/observe ~registry :elapsed-time {:id ~id} (- end# start#))
+         end# (. System (nanoTime))]
+     (prometheus/observe ~registry :elapsed-time {:id ~id} (/ (double (- end# start#)) 1000000.0))
      result#))
 
 (s/defn expose-metrics-http-request-handler


### PR DESCRIPTION
### Changed

- Refactor the `with-elapsed-time` macro to be `report-elapsed-time!` use the proper `System/nanoTime`.